### PR TITLE
Updated README: Added steps to generate GeoPlot visualization & placeholder image.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,28 @@ for i in range(0, num_episodes):
 If you want to track how **consumers’ money spent** changes **over time** in the simulation,  
 you will set `entity_property = "consumers/money_spent"`.  
 
+## 📌 Generating the GeoPlot Visualization  
+
+The `GeoPlot.visualize()` function generates a **3D visualization** using **Cesium Ion** and **GeoJSON data**.  
+To see the output, follow these steps:  
+
+### 🔹 How to Generate the Visualization  
+1. Run the following Python script:  
+   ```python
+   from agent_torch.visualize import GeoPlot
+
+   # Create a GeoPlot instance
+   geoplot = GeoPlot(config, cesium_token)
+
+   # Run the simulation and generate visualization
+   geoplot.visualize(
+       name = "sample-visualization",
+       state_trajectory = runner.state_trajectory,
+       entity_position = "consumers/coordinates",
+       entity_property = "consumers/money_spent",
+   )
+
+
 
 
 

--- a/readme.md
+++ b/readme.md
@@ -36,3 +36,20 @@ for i in range(0, num_episodes):
     entity_property = "consumers/money_spent",
   )
 ```
+### 📌 Explanation of Parameters in `geoplot.visualize(...)`
+
+| Parameter          | Description |
+|-------------------|-------------|
+| `name`  | A string specifying the **file name** for the generated GeoPlot visualization. |
+| `state_trajectory` | The complete **state history** of the simulation. Used to track movement over time. |
+| `entity_position` | The **path in the simulation state** where the entity’s coordinates (latitude, longitude) are stored. |
+| `entity_property` | The **path in the simulation state** where the **property to visualize** is stored (e.g., money spent, distance traveled). |
+
+🔹 **Example Use Case:**  
+If you want to track how **consumers’ money spent** changes **over time** in the simulation,  
+you will set `entity_property = "consumers/money_spent"`.  
+
+
+
+
+


### PR DESCRIPTION
## What this PR does:
- Added a detailed explanation of the parameters used in `geoplot.visualize(...)`.
- Provided instructions on how users can generate the 3D GeoPlot visualization.
- Added a placeholder image to show expected output.

## Why this is needed:
- The previous README lacked a clear explanation of `geoplot.visualize()` parameters.
- There was no mention of how to **generate the HTML output** for visualization.
- This update helps new contributors understand how the visualization works.

## What to Check:
- Ensure the README changes are clear and easy to follow.
- Check if more details are needed for any parameter.

---
Let me know if any improvements are needed! 🚀😊
