### PR TITLE
Update dependencies: Support torch >=2.0,<3.0 and torch_geometric >=2.5,<3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ requires-python = ">= 3.8"
 dependencies = [
     "numpy",
     "pandas",
+    "torch>=2.0.0,<3.0.0",
+    "torch_geometric>=2.5.0,<3.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

This pull request updates the `pyproject.toml` to support newer versions of torch and torch_geometric, while ensuring compatibility within major version 2.x.

- Updated `torch` to `>=2.0.0,<3.0.0`
- Updated `torch_geometric` to `>=2.5.0,<3.0.0`

Previously, `torch` and `torch_geometric` were missing from the `dependencies` list in `pyproject.toml`.
This PR explicitly adds them with safe version ranges to ensure that all required libraries are properly specified and compatible with the project setup.
